### PR TITLE
Add option to use the `parking_lot` crate for `Mutex`/`Condvar`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,13 @@ log = ["dep:log"]
 log_parallelism = ["log"]
 nightly = []
 nightly_tests = []
+parking_lot = ["dep:parking_lot"]
 rayon = ["dep:rayon-core"]
 
 [dependencies]
 crossbeam-utils = "0.8.21"
 log = { optional = true, version = "0.4" }
+parking_lot = { optional = true, version = "0.12.5" }
 rayon-core = { optional = true, version = "1.13.0" }
 
 # Platforms that support `libc::sched_setaffinity()`.


### PR DESCRIPTION
As mentioned in https://github.com/gendx/paralight/issues/19#issuecomment-3612833108, the [`parking_lot` crate](https://docs.rs/parking_lot) is an option to explore to improve the performance of the `Status` utility. This pull request adds experimental support for it, gated by the `parking_lot` crate.

From a quick look of some examples on Linux, performance isn't better than the standard library implementation, so I'm leaving this pull request open until someone shows a scenario where `parking_lot` improves performance as a back-end for Paralight.