### PR TITLE
Fix IterReducer unwrap panic when `iter` is empty

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# Fix for the default linker crashing on large symbol names:
+# https://github.com/rust-lang/rust/issues/141626
+[target.'cfg(target_os = "windows")']
+linker = "rust-lld"

--- a/src/iter/detail.rs
+++ b/src/iter/detail.rs
@@ -63,13 +63,13 @@ pub struct IterReducer<Reduce> {
     pub(super) reduce: Reduce,
 }
 
-impl<Output, Reduce> ExactSizeAccumulator<Output, Output> for IterReducer<Reduce>
+impl<Output, Reduce> ExactSizeAccumulator<Output, Option<Output>> for IterReducer<Reduce>
 where
     Reduce: Fn(Output, Output) -> Output,
 {
     #[inline(always)]
-    fn accumulate_exact(&self, iter: impl ExactSizeIterator<Item = Output>) -> Output {
-        iter.reduce(&self.reduce).unwrap()
+    fn accumulate_exact(&self, iter: impl ExactSizeIterator<Item = Output>) -> Option<Output> {
+        iter.reduce(&self.reduce)
     }
 }
 

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -208,12 +208,13 @@ pub trait ParallelIterator: Sized {
     ) -> Output {
         self.iter_pipeline(
             IterAccumulator {
-                init,
+                init: &init,
                 process_item,
-                finalize,
+                finalize: &finalize,
             },
             IterReducer { reduce },
         )
+        .unwrap_or_else(|| finalize(init()))
     }
 
     /// Runs the pipeline defined by the given functions on this iterator.
@@ -267,12 +268,13 @@ pub trait ParallelIterator: Sized {
         self.iter_pipeline(
             ShortCircuitingAccumulator {
                 fuse: Fuse::new(),
-                init,
+                init: &init,
                 process_item,
-                finalize,
+                finalize: &finalize,
             },
             IterReducer { reduce },
         )
+        .unwrap_or_else(|| finalize(ControlFlow::Continue(init())))
     }
 
     /// Runs the pipeline defined by the given functions on this iterator.
@@ -329,12 +331,13 @@ pub trait ParallelIterator: Sized {
         self.iter_pipeline(
             ShortCircuitingAccumulator {
                 fuse: Fuse::new(),
-                init,
+                init: &init,
                 process_item,
-                finalize,
+                finalize: &finalize,
             },
             IterReducer { reduce },
         )
+        .unwrap_or_else(|| finalize(Try::from_output(init())))
     }
 
     /// Runs the pipeline defined by the given functions on this iterator.


### PR DESCRIPTION
When using `paralight` with [`micropool`](https://github.com/DouglasDwyer/micropool), I encountered the following panic:

```
thread '<unnamed>' (11060) panicked at C:\Users\Douglas\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\paralight-0.0.10\src\iter\detail.rs:72:35:
called `Option::unwrap()` on a `None` value
```

This happens when `iter` is empty in this function:
```rust
  #[inline(always)]
  fn accumulate_exact(&self, iter: impl ExactSizeIterator<Item = Output>) -> Output {
      iter.reduce(&self.reduce).unwrap()
  }
```

With the builtin `paralight` pool, the number of items in `iter` is equal to the number of threads. As such, this never happens. However, `micropool` uses other splitting strategies and may pass an empty iterator here. This PR fixes the problem by replacing `unwrap` with `unwrap_or_else` with a call to a default function. 